### PR TITLE
Add initial docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM lnl7/nix:2.1.2
+
+RUN nix-env -iA \
+ nixpkgs.curl \
+ nixpkgs.rustup \
+ nixpkgs.bashInteractive


### PR DESCRIPTION
First attempt at creating a working docker file.
The docker file should just create a docker image of a simple nix environment, from which the backend can be compiled.

This will at the very least require node to be installed later.